### PR TITLE
Add reference check to HashAddress.Equals

### DIFF
--- a/HydraScript.Lib/BackEnd/Addresses/HashAddress.cs
+++ b/HydraScript.Lib/BackEnd/Addresses/HashAddress.cs
@@ -3,7 +3,7 @@ namespace HydraScript.Lib.BackEnd.Addresses;
 public class HashAddress : IAddress
 {
     private readonly int _seed;
-    
+
     public IAddress Next { get; set; }
 
     public HashAddress(int seed) =>
@@ -11,10 +11,26 @@ public class HashAddress : IAddress
 
     public bool Equals(IAddress other)
     {
-        if (other is HashAddress hashed)
-            return _seed == hashed._seed;
+        if (other is HashAddress _)
+            return Equals(other);
 
         return false;
+    }
+
+    public override bool Equals(object obj)
+    {
+        if (!ReferenceEquals(this, obj))
+            return false;
+        
+        if (obj.GetType() != GetType())
+            return false;
+
+        return Equals((HashAddress)obj);
+    }
+
+    protected bool Equals(HashAddress other)
+    {
+        return _seed == other._seed;
     }
 
     public override int GetHashCode()

--- a/HydraScript.Tests/Unit/BackEnd/HashAddressTests.cs
+++ b/HydraScript.Tests/Unit/BackEnd/HashAddressTests.cs
@@ -1,0 +1,35 @@
+using HydraScript.Lib.BackEnd.Addresses;
+using Xunit;
+
+namespace HydraScript.Tests.Unit.BackEnd;
+
+public class HashAddressTests
+{
+    [Fact]
+    public void EqualsReturnsFalseForTwoDifferentObjectsWithSameSeed()
+    {
+        const int seed = 1;
+
+        var addressOne = new HashAddress(seed);
+        var addressTwo = new HashAddress(seed);
+
+        Assert.NotEqual(addressOne, addressTwo);
+    }
+    
+    [Fact]
+    public void EqualsReturnsTrueForTwoSameOjectsWithSameSeed()
+    {
+        var address = new HashAddress(1);
+
+        Assert.Equal(address, address);
+    }
+    
+    [Fact]
+    public void EqualsReturnsFalseForTwoObjectsWithDifferentSeed()
+    {
+        var addressOne = new HashAddress(0);
+        var addressTwo = new HashAddress(1);
+
+        Assert.NotEqual(addressOne, addressTwo);
+    }
+}


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->


### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### References
<!--- References would be helpful to understand the changes. -->
<!--- References can be books, links, etc. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [ ] I have added corresponding labels with respect to the part of the interpreter i've worked on.
