### PR TITLE
Add unique Guid check to HashAddress.Equals

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -8,6 +8,13 @@ on:
     branches:
       - '**'
 
+permissions:
+  actions: write
+  checks: write
+  contents: write
+  issues: write
+  pull-requests: write
+
 jobs:
   build-and-test:
     name: Build & Test

--- a/HydraScript.Lib/BackEnd/Addresses/HashAddress.cs
+++ b/HydraScript.Lib/BackEnd/Addresses/HashAddress.cs
@@ -3,6 +3,8 @@ namespace HydraScript.Lib.BackEnd.Addresses;
 public class HashAddress : IAddress
 {
     private readonly int _seed;
+
+    private readonly Guid _id = Guid.NewGuid();
     
     public IAddress Next { get; set; }
 
@@ -12,7 +14,7 @@ public class HashAddress : IAddress
     public bool Equals(IAddress other)
     {
         if (other is HashAddress hashed)
-            return _seed == hashed._seed;
+            return _seed == hashed._seed && _id == hashed._id;
 
         return false;
     }

--- a/HydraScript.Tests/Unit/BackEnd/HashAddressTests.cs
+++ b/HydraScript.Tests/Unit/BackEnd/HashAddressTests.cs
@@ -1,0 +1,35 @@
+using HydraScript.Lib.BackEnd.Addresses;
+using Xunit;
+
+namespace HydraScript.Tests.Unit.BackEnd;
+
+public class HashAddressTests
+{
+    [Fact]
+    public void EqualsReturnsFalseForTwoDifferentObjectsWithSameSeed()
+    {
+        const int seed = 1;
+
+        var addressOne = new HashAddress(seed);
+        var addressTwo = new HashAddress(seed);
+
+        Assert.NotEqual(addressOne, addressTwo);
+    }
+    
+    [Fact]
+    public void EqualsReturnsTrueForTwoSameOjectsWithSameSeed()
+    {
+        var address = new HashAddress(1);
+
+        Assert.Equal(address, address);
+    }
+    
+    [Fact]
+    public void EqualsReturnsFalseForTwoObjectsWithDifferentSeed()
+    {
+        var addressOne = new HashAddress(0);
+        var addressTwo = new HashAddress(1);
+
+        Assert.NotEqual(addressOne, addressTwo);
+    }
+}


### PR DESCRIPTION
### Description
Добавляет приватное поле типа Guid для определения уникальности экземпляра в Equals.


### Related Issues
https://github.com/Stepami/hydrascript/issues/29


### References
Не применимо


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [x] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [ ] I have added corresponding labels with respect to the part of the interpreter i've worked on.
