### PR TITLE
#59 - переход на IReadOnlyList

### DIFF
--- a/src/HydraScript.Lib/FrontEnd/GetTokens/Data/Token.cs
+++ b/src/HydraScript.Lib/FrontEnd/GetTokens/Data/Token.cs
@@ -31,6 +31,9 @@ public record Segment(Coordinates Start, Coordinates End)
 
     public static Segment operator +(Segment left, Segment right) => 
         new(left.Start, right.End);
+
+    public static implicit operator string(Segment segment) =>
+        segment.ToString();
 }
     
 [ExcludeFromCodeCoverage]

--- a/src/HydraScript.Lib/FrontEnd/TopDownParse/Impl/Parser.cs
+++ b/src/HydraScript.Lib/FrontEnd/TopDownParse/Impl/Parser.cs
@@ -492,7 +492,10 @@ public class Parser : IParser
             var consequent = Expression();
             Expect("Colon");
             var alternate = Expression();
-            return new ConditionalExpression(test, consequent, alternate);
+            return new ConditionalExpression(test, consequent, alternate)
+            {
+                Segment = consequent.Segment + alternate.Segment
+            };
         }
 
         return test;

--- a/src/HydraScript.Lib/IR/Ast/AbstractSyntaxTreeNode.cs
+++ b/src/HydraScript.Lib/IR/Ast/AbstractSyntaxTreeNode.cs
@@ -4,7 +4,7 @@ using HydraScript.Lib.IR.CheckSemantics.Variables;
 namespace HydraScript.Lib.IR.Ast;
 
 public abstract class AbstractSyntaxTreeNode :
-    IEnumerable<AbstractSyntaxTreeNode>,
+    IReadOnlyList<AbstractSyntaxTreeNode>,
     IVisitable<AbstractSyntaxTreeNode>
 {
     public AbstractSyntaxTreeNode Parent { get; set; } = default!;
@@ -15,16 +15,24 @@ public abstract class AbstractSyntaxTreeNode :
 
     public string Segment { get; init; } = string.Empty;
 
+    protected virtual IReadOnlyList<AbstractSyntaxTreeNode> Children { get; } = [];
+
+    public IEnumerator<AbstractSyntaxTreeNode> GetEnumerator() =>
+        Children.ToList().GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() =>
+        GetEnumerator();
+
+    public int Count => Children.Count;
+
+    public AbstractSyntaxTreeNode this[int index] =>
+        Children[index];
+
     internal List<AbstractSyntaxTreeNode> GetAllNodes()
     {
-        var result = new List<AbstractSyntaxTreeNode>
-        {
-            this
-        };
-        foreach (var child in this)
-        {
-            result.AddRange(child.GetAllNodes());
-        }
+        List<AbstractSyntaxTreeNode> result = [this];
+        for (var index = 0; index < Children.Count; index++)
+            result.AddRange(Children[index].GetAllNodes());
 
         return result;
     }
@@ -44,11 +52,6 @@ public abstract class AbstractSyntaxTreeNode :
 
         return false;
     }
-
-    public abstract IEnumerator<AbstractSyntaxTreeNode> GetEnumerator();
-
-    IEnumerator IEnumerable.GetEnumerator() =>
-        GetEnumerator();
 
     public virtual TReturn Accept<TReturn>(IVisitor<AbstractSyntaxTreeNode, TReturn> visitor) =>
         visitor.DefaultVisit;

--- a/src/HydraScript.Lib/IR/Ast/AbstractSyntaxTreeNode.cs
+++ b/src/HydraScript.Lib/IR/Ast/AbstractSyntaxTreeNode.cs
@@ -8,7 +8,9 @@ public abstract class AbstractSyntaxTreeNode :
     IEnumerable<AbstractSyntaxTreeNode>,
     IVisitable<AbstractSyntaxTreeNode>
 {
-    public AbstractSyntaxTreeNode? Parent { get; set; }
+    public AbstractSyntaxTreeNode Parent { get; set; } = default!;
+
+    protected virtual bool IsRoot => false;
 
     public SymbolTable SymbolTable { get; set; } = default!;
 
@@ -31,7 +33,7 @@ public abstract class AbstractSyntaxTreeNode :
     public bool ChildOf<T>() where T : AbstractSyntaxTreeNode
     {
         var parent = Parent;
-        while (parent != null)
+        while (!parent.IsRoot)
         {
             if (parent is T)
             {

--- a/src/HydraScript.Lib/IR/Ast/AbstractSyntaxTreeNode.cs
+++ b/src/HydraScript.Lib/IR/Ast/AbstractSyntaxTreeNode.cs
@@ -1,5 +1,4 @@
 using System.Collections;
-using HydraScript.Lib.FrontEnd.GetTokens.Data;
 using HydraScript.Lib.IR.CheckSemantics.Variables;
 
 namespace HydraScript.Lib.IR.Ast;
@@ -14,7 +13,7 @@ public abstract class AbstractSyntaxTreeNode :
 
     public SymbolTable SymbolTable { get; set; } = default!;
 
-    public Segment Segment { get; init; } = default!;
+    public string Segment { get; init; } = string.Empty;
 
     internal List<AbstractSyntaxTreeNode> GetAllNodes()
     {

--- a/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Declarations/AfterTypesAreLoaded/FunctionDeclaration.cs
+++ b/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Declarations/AfterTypesAreLoaded/FunctionDeclaration.cs
@@ -6,7 +6,7 @@ namespace HydraScript.Lib.IR.Ast.Impl.Nodes.Declarations.AfterTypesAreLoaded;
 [AutoVisitable<AbstractSyntaxTreeNode>]
 public partial class FunctionDeclaration : AfterTypesAreLoadedDeclaration
 {
-    private IReadOnlyCollection<ReturnStatement>? _returnStatements;
+    protected override IReadOnlyList<AbstractSyntaxTreeNode> Children => [Statements];
 
     public IdentifierReference Name { get; }
     public TypeValue ReturnTypeValue { get; }
@@ -25,24 +25,17 @@ public partial class FunctionDeclaration : AfterTypesAreLoadedDeclaration
 
         Statements = blockStatement;
         Statements.Parent = this;
-    }
 
-    public bool HasReturnStatement()
-    {
-        _returnStatements ??= GetReturnStatements();
-        return _returnStatements.Count > 0;
-    }
-
-    public IReadOnlyCollection<ReturnStatement> GetReturnStatements() =>
-        _returnStatements ??= Statements
+        ReturnStatements = Statements
             .GetAllNodes()
             .OfType<ReturnStatement>()
             .ToArray();
-
-    public override IEnumerator<AbstractSyntaxTreeNode> GetEnumerator()
-    {
-        yield return Statements;
     }
+
+    public bool HasReturnStatement() =>
+        ReturnStatements.Count > 0;
+
+    public IReadOnlyCollection<ReturnStatement> ReturnStatements { get; }
 
     protected override string NodeRepresentation() =>
         "function " + Name;

--- a/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Declarations/AfterTypesAreLoaded/LexicalDeclaration.cs
+++ b/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Declarations/AfterTypesAreLoaded/LexicalDeclaration.cs
@@ -5,17 +5,19 @@ namespace HydraScript.Lib.IR.Ast.Impl.Nodes.Declarations.AfterTypesAreLoaded;
 [AutoVisitable<AbstractSyntaxTreeNode>]
 public partial class LexicalDeclaration(bool readOnly) : AfterTypesAreLoadedDeclaration
 {
+    private readonly List<AssignmentExpression> _assignments = [];
+    protected override IReadOnlyList<AbstractSyntaxTreeNode> Children =>
+        _assignments;
+
     public bool ReadOnly { get; } = readOnly;
-    public List<AssignmentExpression> Assignments { get; } = [];
+    public IReadOnlyList<AssignmentExpression> Assignments =>
+        _assignments;
 
     public void AddAssignment(AssignmentExpression assignment)
     {
         assignment.Parent = this;
-        Assignments.Add(assignment);
+        _assignments.Add(assignment);
     }
-
-    public override IEnumerator<AbstractSyntaxTreeNode> GetEnumerator() =>
-        Assignments.GetEnumerator();
 
     protected override string NodeRepresentation() =>
         ReadOnly ? "const" : "let";

--- a/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Declarations/TypeDeclaration.cs
+++ b/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Declarations/TypeDeclaration.cs
@@ -3,25 +3,13 @@ using HydraScript.Lib.IR.Ast.Impl.Nodes.Expressions.PrimaryExpressions;
 namespace HydraScript.Lib.IR.Ast.Impl.Nodes.Declarations;
 
 [AutoVisitable<AbstractSyntaxTreeNode>]
-public partial class TypeDeclaration : Declaration
+public partial class TypeDeclaration(IdentifierReference typeId, TypeValue typeValue) : Declaration
 {
-    private readonly TypeValue _typeValue;
-    public IdentifierReference TypeId { get; }
-
-    public TypeDeclaration(IdentifierReference typeId, TypeValue typeValue)
-    {
-        TypeId = typeId;
-        _typeValue = typeValue;
-    }
+    public IdentifierReference TypeId { get; } = typeId;
 
     public Type BuildType() =>
-        _typeValue.BuildType(SymbolTable);
-
-    public override IEnumerator<AbstractSyntaxTreeNode> GetEnumerator()
-    {
-        yield break;
-    }
+        typeValue.BuildType(SymbolTable);
 
     protected override string NodeRepresentation() =>
-        $"type {TypeId.Name} = {_typeValue}";
+        $"type {TypeId.Name} = {typeValue}";
 }

--- a/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Expressions/AccessExpressions/DotAccess.cs
+++ b/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Expressions/AccessExpressions/DotAccess.cs
@@ -5,21 +5,15 @@ namespace HydraScript.Lib.IR.Ast.Impl.Nodes.Expressions.AccessExpressions;
 [AutoVisitable<AbstractSyntaxTreeNode>]
 public partial class DotAccess : AccessExpression
 {
+    protected override IReadOnlyList<AbstractSyntaxTreeNode> Children =>
+        HasNext() ? [Property, Next!] : [Property];
+
     public IdentifierReference Property { get; }
 
     public DotAccess(IdentifierReference property, AccessExpression? prev = null) : base(prev)
     {
         Property = property;
         Property.Parent = this;
-    }
-
-    public override IEnumerator<AbstractSyntaxTreeNode> GetEnumerator()
-    {
-        yield return Property;
-        if (HasNext())
-        {
-            yield return Next!;
-        }
     }
 
     protected override string NodeRepresentation() => ".";

--- a/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Expressions/AccessExpressions/IndexAccess.cs
+++ b/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Expressions/AccessExpressions/IndexAccess.cs
@@ -3,21 +3,15 @@ namespace HydraScript.Lib.IR.Ast.Impl.Nodes.Expressions.AccessExpressions;
 [AutoVisitable<AbstractSyntaxTreeNode>]
 public partial class IndexAccess : AccessExpression
 {
+    protected override IReadOnlyList<AbstractSyntaxTreeNode> Children =>
+        HasNext() ? [Index, Next!] : [Index];
+
     public Expression Index { get; }
 
     public IndexAccess(Expression index, AccessExpression? prev = null) : base(prev)
     {
         Index = index;
         Index.Parent = this;
-    }
-
-    public override IEnumerator<AbstractSyntaxTreeNode> GetEnumerator()
-    {
-        yield return Index;
-        if (HasNext())
-        {
-            yield return Next!;
-        }
     }
 
     protected override string NodeRepresentation() => "[]";

--- a/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Expressions/AssignmentExpression.cs
+++ b/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Expressions/AssignmentExpression.cs
@@ -5,6 +5,9 @@ namespace HydraScript.Lib.IR.Ast.Impl.Nodes.Expressions;
 [AutoVisitable<AbstractSyntaxTreeNode>]
 public partial class AssignmentExpression : Expression
 {
+    protected override IReadOnlyList<AbstractSyntaxTreeNode> Children =>
+        [Destination, Source];
+
     public LeftHandSideExpression Destination { get; }
     public Expression Source { get; }
     public TypeValue? DestinationType { get; }
@@ -21,12 +24,6 @@ public partial class AssignmentExpression : Expression
         source.Parent = this;
 
         DestinationType = destinationType;
-    }
-
-    public override IEnumerator<AbstractSyntaxTreeNode> GetEnumerator()
-    {
-        yield return Destination;
-        yield return Source;
     }
 
     protected override string NodeRepresentation() => "=";

--- a/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Expressions/BinaryExpression.cs
+++ b/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Expressions/BinaryExpression.cs
@@ -3,6 +3,9 @@ namespace HydraScript.Lib.IR.Ast.Impl.Nodes.Expressions;
 [AutoVisitable<AbstractSyntaxTreeNode>]
 public partial class BinaryExpression : Expression
 {
+    protected override IReadOnlyList<AbstractSyntaxTreeNode> Children =>
+        [Left, Right];
+
     public Expression Left { get; }
     public string Operator { get; }
     public Expression Right { get; }
@@ -16,12 +19,6 @@ public partial class BinaryExpression : Expression
 
         Right = right;
         Right.Parent = this;
-    }
-
-    public override IEnumerator<AbstractSyntaxTreeNode> GetEnumerator()
-    {
-        yield return Left;
-        yield return Right;
     }
 
     protected override string NodeRepresentation() => Operator;

--- a/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Expressions/CallExpression.cs
+++ b/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Expressions/CallExpression.cs
@@ -5,33 +5,26 @@ namespace HydraScript.Lib.IR.Ast.Impl.Nodes.Expressions;
 [AutoVisitable<AbstractSyntaxTreeNode>]
 public partial class CallExpression : LeftHandSideExpression
 {
+    private readonly List<Expression> _parameters;
+
+    protected override IReadOnlyList<AbstractSyntaxTreeNode> Children =>
+        [Member, .._parameters];
+
     public MemberExpression Member { get; }
-    public List<Expression> Parameters { get; }
+    public IReadOnlyList<Expression> Parameters => _parameters;
 
     public CallExpression(MemberExpression member, IEnumerable<Expression> expressions)
     {
         Member = member;
         Member.Parent = this;
 
-        Parameters = new List<Expression>(expressions);
-        Parameters.ForEach(expr => expr.Parent = this);
+        _parameters = new List<Expression>(expressions);
+        _parameters.ForEach(expr => expr.Parent = this);
     }
 
-    public override IdentifierReference Id =>
-        Member.Id;
+    public override IdentifierReference Id => Member.Id;
 
-    public override bool Empty() =>
-        Member.Empty();
-
-    public override IEnumerator<AbstractSyntaxTreeNode> GetEnumerator()
-    {
-        var nodes = new List<AbstractSyntaxTreeNode>
-        {
-            Member
-        };
-        nodes.AddRange(Parameters);
-        return nodes.GetEnumerator();
-    }
+    public override bool Empty() => Member.Empty();
 
     protected override string NodeRepresentation() => "()";
 }

--- a/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Expressions/CastAsExpression.cs
+++ b/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Expressions/CastAsExpression.cs
@@ -5,6 +5,9 @@ namespace HydraScript.Lib.IR.Ast.Impl.Nodes.Expressions;
 [AutoVisitable<AbstractSyntaxTreeNode>]
 public partial class CastAsExpression : Expression
 {
+    protected override IReadOnlyList<AbstractSyntaxTreeNode> Children =>
+        [Expression];
+
     public Expression Expression { get; }
     public TypeValue Cast { get; }
 
@@ -14,11 +17,6 @@ public partial class CastAsExpression : Expression
         Expression.Parent = this;
 
         Cast = cast;
-    }
-
-    public override IEnumerator<AbstractSyntaxTreeNode> GetEnumerator()
-    {
-        yield return Expression;
     }
 
     protected override string NodeRepresentation() => $"as {Cast}";

--- a/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Expressions/ComplexLiterals/ArrayLiteral.cs
+++ b/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Expressions/ComplexLiterals/ArrayLiteral.cs
@@ -3,16 +3,18 @@ namespace HydraScript.Lib.IR.Ast.Impl.Nodes.Expressions.ComplexLiterals;
 [AutoVisitable<AbstractSyntaxTreeNode>]
 public partial class ArrayLiteral : ComplexLiteral
 {
-    public List<Expression> Expressions { get; }
+    private readonly List<Expression> _expressions;
+
+    protected override IReadOnlyList<AbstractSyntaxTreeNode> Children =>
+        _expressions;
+
+    public IReadOnlyList<Expression> Expressions => _expressions;
 
     public ArrayLiteral(IEnumerable<Expression> expressions)
     {
-        Expressions = new List<Expression>(expressions);
-        Expressions.ForEach(expr => expr.Parent = this);
+        _expressions = new List<Expression>(expressions);
+        _expressions.ForEach(expr => expr.Parent = this);
     }
-
-    public override IEnumerator<AbstractSyntaxTreeNode> GetEnumerator() =>
-        Expressions.GetEnumerator();
 
     protected override string NodeRepresentation() => "[]";
 }

--- a/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Expressions/ComplexLiterals/ObjectLiteral.cs
+++ b/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Expressions/ComplexLiterals/ObjectLiteral.cs
@@ -3,16 +3,18 @@ namespace HydraScript.Lib.IR.Ast.Impl.Nodes.Expressions.ComplexLiterals;
 [AutoVisitable<AbstractSyntaxTreeNode>]
 public partial class ObjectLiteral : ComplexLiteral
 {
-    public List<Property> Properties { get; }
+    private readonly List<Property> _properties;
+
+    protected override IReadOnlyList<AbstractSyntaxTreeNode> Children =>
+        _properties;
+
+    public IReadOnlyList<Property> Properties => _properties;
 
     public ObjectLiteral(IEnumerable<Property> properties)
     {
-        Properties = new List<Property>(properties);
-        Properties.ForEach(prop => prop.Parent = this);
+        _properties = new List<Property>(properties);
+        _properties.ForEach(prop => prop.Parent = this);
     }
-
-    public override IEnumerator<AbstractSyntaxTreeNode> GetEnumerator() =>
-        Properties.GetEnumerator();
 
     protected override string NodeRepresentation() => "{}";
 }

--- a/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Expressions/ComplexLiterals/Property.cs
+++ b/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Expressions/ComplexLiterals/Property.cs
@@ -5,6 +5,9 @@ namespace HydraScript.Lib.IR.Ast.Impl.Nodes.Expressions.ComplexLiterals;
 [AutoVisitable<AbstractSyntaxTreeNode>]
 public partial class Property : Expression
 {
+    protected override IReadOnlyList<AbstractSyntaxTreeNode> Children =>
+        [Id, Expression];
+
     public IdentifierReference Id { get; }
     public Expression Expression { get; }
 
@@ -24,12 +27,6 @@ public partial class Property : Expression
     {
         id = Id.Name;
         expr = Expression;
-    }
-   
-    public override IEnumerator<AbstractSyntaxTreeNode> GetEnumerator()
-    {
-        yield return Id;
-        yield return Expression;
     }
 
     protected override string NodeRepresentation() => ":";

--- a/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Expressions/ConditionalExpression.cs
+++ b/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Expressions/ConditionalExpression.cs
@@ -3,6 +3,9 @@ namespace HydraScript.Lib.IR.Ast.Impl.Nodes.Expressions;
 [AutoVisitable<AbstractSyntaxTreeNode>]
 public partial class ConditionalExpression : Expression
 {
+    protected override IReadOnlyList<AbstractSyntaxTreeNode> Children =>
+        [Test, Consequent, Alternate];
+
     public Expression Test { get; }
     public Expression Consequent { get; }
     public Expression Alternate { get; }
@@ -16,13 +19,6 @@ public partial class ConditionalExpression : Expression
         Test.Parent = this;
         Consequent.Parent = this;
         Alternate.Parent = this;
-    }
-
-    public override IEnumerator<AbstractSyntaxTreeNode> GetEnumerator()
-    {
-        yield return Test;
-        yield return Consequent;
-        yield return Alternate;
     }
 
     protected override string NodeRepresentation() => "?:";

--- a/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Expressions/MemberExpression.cs
+++ b/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Expressions/MemberExpression.cs
@@ -8,24 +8,25 @@ public partial class MemberExpression : LeftHandSideExpression
 {
     private readonly IdentifierReference _identifierReference;
 
+    protected override IReadOnlyList<AbstractSyntaxTreeNode> Children =>
+        AccessChain is not null ? [Id, AccessChain] : [Id];
+
     public AccessExpression? AccessChain { get; }
     public AccessExpression? Tail { get; }
 
     public Type ComputedIdType { get; set; } = default!;
 
-    public MemberExpression(IdentifierReference identifierReference) :
-        this(identifierReference, accessChain: null, tail: null)
+    public MemberExpression(IdentifierReference identifierReference)
     {
+        _identifierReference = identifierReference;
+        _identifierReference.Parent = this;
     }
 
     public MemberExpression(
         IdentifierReference identifierReference,
         AccessExpression? accessChain,
-        AccessExpression? tail)
+        AccessExpression? tail) : this(identifierReference)
     {
-        _identifierReference = identifierReference;
-        _identifierReference.Parent = this;
-
         AccessChain = accessChain;
         if (AccessChain is not null)
         {
@@ -35,20 +36,9 @@ public partial class MemberExpression : LeftHandSideExpression
         Tail = tail;
     }
 
-    public override IdentifierReference Id =>
-        _identifierReference;
+    public override IdentifierReference Id => _identifierReference;
 
-    public override bool Empty() =>
-        AccessChain is null;
-
-    public override IEnumerator<AbstractSyntaxTreeNode> GetEnumerator()
-    {
-        yield return Id;
-        if (AccessChain is not null)
-        {
-            yield return AccessChain;
-        }
-    }
+    public override bool Empty() => AccessChain is null;
 
     protected override string NodeRepresentation() => nameof(MemberExpression);
 }

--- a/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Expressions/PrimaryExpressions/PrimaryExpression.cs
+++ b/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Expressions/PrimaryExpressions/PrimaryExpression.cs
@@ -5,10 +5,5 @@ namespace HydraScript.Lib.IR.Ast.Impl.Nodes.Expressions.PrimaryExpressions;
 [AutoVisitable<AbstractSyntaxTreeNode>]
 public abstract partial class PrimaryExpression : Expression
 {
-    public override IEnumerator<AbstractSyntaxTreeNode> GetEnumerator()
-    {
-        yield break;
-    }
-
     public abstract IValue ToValue();
 }

--- a/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Expressions/UnaryExpression.cs
+++ b/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Expressions/UnaryExpression.cs
@@ -3,6 +3,9 @@ namespace HydraScript.Lib.IR.Ast.Impl.Nodes.Expressions;
 [AutoVisitable<AbstractSyntaxTreeNode>]
 public partial class UnaryExpression : Expression
 {
+    protected override IReadOnlyList<AbstractSyntaxTreeNode> Children =>
+        [Expression];
+
     public string Operator { get; }
     public Expression Expression { get; }
 
@@ -12,11 +15,6 @@ public partial class UnaryExpression : Expression
 
         Expression = expression;
         Expression.Parent = this;
-    }
-
-    public override IEnumerator<AbstractSyntaxTreeNode> GetEnumerator()
-    {
-        yield return Expression;
     }
 
     protected override string NodeRepresentation() => Operator;

--- a/src/HydraScript.Lib/IR/Ast/Impl/Nodes/ScriptBody.cs
+++ b/src/HydraScript.Lib/IR/Ast/Impl/Nodes/ScriptBody.cs
@@ -3,18 +3,19 @@ namespace HydraScript.Lib.IR.Ast.Impl.Nodes;
 [AutoVisitable<AbstractSyntaxTreeNode>]
 public partial class ScriptBody : AbstractSyntaxTreeNode
 {
-    public List<StatementListItem> StatementList { get; }
+    private readonly List<StatementListItem> _statementList;
+
+    protected override IReadOnlyList<AbstractSyntaxTreeNode> Children =>
+        _statementList;
+    protected override bool IsRoot => true;
+
+    public IReadOnlyList<StatementListItem> StatementList => _statementList;
 
     public ScriptBody(IEnumerable<StatementListItem> statementList)
     {
-        StatementList = new List<StatementListItem>(statementList);
-        StatementList.ForEach(item => item.Parent = this);
+        _statementList = new List<StatementListItem>(statementList);
+        _statementList.ForEach(item => item.Parent = this);
     }
-
-    protected override bool IsRoot => true;
-
-    public override IEnumerator<AbstractSyntaxTreeNode> GetEnumerator() =>
-        StatementList.GetEnumerator();
 
     protected override string NodeRepresentation() => "Script";
 }

--- a/src/HydraScript.Lib/IR/Ast/Impl/Nodes/ScriptBody.cs
+++ b/src/HydraScript.Lib/IR/Ast/Impl/Nodes/ScriptBody.cs
@@ -11,6 +11,8 @@ public partial class ScriptBody : AbstractSyntaxTreeNode
         StatementList.ForEach(item => item.Parent = this);
     }
 
+    protected override bool IsRoot => true;
+
     public override IEnumerator<AbstractSyntaxTreeNode> GetEnumerator() =>
         StatementList.GetEnumerator();
 

--- a/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Statements/BlockStatement.cs
+++ b/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Statements/BlockStatement.cs
@@ -3,16 +3,18 @@ namespace HydraScript.Lib.IR.Ast.Impl.Nodes.Statements;
 [AutoVisitable<AbstractSyntaxTreeNode>]
 public partial class BlockStatement : Statement
 {
-    public List<StatementListItem> StatementList { get; }
+    private readonly List<StatementListItem> _statementList;
+
+    protected override IReadOnlyList<AbstractSyntaxTreeNode> Children =>
+        _statementList;
+
+    public IReadOnlyList<StatementListItem> StatementList => _statementList;
 
     public BlockStatement(IEnumerable<StatementListItem> statementList)
     {
-        StatementList = new List<StatementListItem>(statementList);
-        StatementList.ForEach(item => item.Parent = this);
+        _statementList = new List<StatementListItem>(statementList);
+        _statementList.ForEach(item => item.Parent = this);
     }
-
-    public override IEnumerator<AbstractSyntaxTreeNode> GetEnumerator() =>
-        StatementList.GetEnumerator();
 
     protected override string NodeRepresentation() => "{}";
 }

--- a/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Statements/ExpressionStatement.cs
+++ b/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Statements/ExpressionStatement.cs
@@ -3,17 +3,15 @@ namespace HydraScript.Lib.IR.Ast.Impl.Nodes.Statements;
 [AutoVisitable<AbstractSyntaxTreeNode>]
 public partial class ExpressionStatement : Statement
 {
+    protected override IReadOnlyList<AbstractSyntaxTreeNode> Children =>
+        [Expression];
+
     public Expression Expression { get; }
 
     public ExpressionStatement(Expression expression)
     {
         Expression = expression;
-        expression.Parent = this;
-    }
-
-    public override IEnumerator<AbstractSyntaxTreeNode> GetEnumerator()
-    {
-        yield return Expression;
+        Expression.Parent = this;
     }
 
     protected override string NodeRepresentation() => nameof(ExpressionStatement);

--- a/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Statements/IfStatement.cs
+++ b/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Statements/IfStatement.cs
@@ -3,6 +3,9 @@ namespace HydraScript.Lib.IR.Ast.Impl.Nodes.Statements;
 [AutoVisitable<AbstractSyntaxTreeNode>]
 public partial class IfStatement : Statement
 {
+    protected override IReadOnlyList<AbstractSyntaxTreeNode> Children =>
+        Else is not null ? [Test, Then, Else] : [Test, Then];
+
     public Expression Test { get; }
     public Statement Then { get; }
     public Statement? Else { get; }
@@ -22,21 +25,13 @@ public partial class IfStatement : Statement
         }
     }
 
-    public bool Empty() =>
-        !Then.Any() && !HasElseBlock();
-
-    public bool HasElseBlock() =>
-        Else is not null && Else.Any();
-
-    public override IEnumerator<AbstractSyntaxTreeNode> GetEnumerator()
+    public bool Empty() => this is
     {
-        yield return Test;
-        yield return Then;
-        if (Else is not null)
-        {
-            yield return Else;
-        }
-    }
+        Then.Count: 0,
+        Else: null or { Count: 0 }
+    };
+
+    public bool HasElseBlock() => Else is { Count: > 0 };
 
     protected override string NodeRepresentation() => "if";
 }

--- a/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Statements/InsideStatementJump.cs
+++ b/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Statements/InsideStatementJump.cs
@@ -8,10 +8,5 @@ public partial class InsideStatementJump(string keyword) : Statement
 
     public string Keyword { get; } = keyword;
 
-    public override IEnumerator<AbstractSyntaxTreeNode> GetEnumerator()
-    {
-        yield break;
-    }
-
     protected override string NodeRepresentation() => Keyword;
 }

--- a/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Statements/ReturnStatement.cs
+++ b/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Statements/ReturnStatement.cs
@@ -3,6 +3,9 @@ namespace HydraScript.Lib.IR.Ast.Impl.Nodes.Statements;
 [AutoVisitable<AbstractSyntaxTreeNode>]
 public partial class ReturnStatement : Statement
 {
+    protected override IReadOnlyList<AbstractSyntaxTreeNode> Children =>
+        Expression is not null ? [Expression] : [];
+
     public Expression? Expression { get; }
 
     public ReturnStatement(Expression? expression = null)
@@ -12,16 +15,6 @@ public partial class ReturnStatement : Statement
         {
             Expression.Parent = this;
         }
-    }
-
-    public override IEnumerator<AbstractSyntaxTreeNode> GetEnumerator()
-    {
-        if (Expression is null)
-        {
-            yield break;
-        }
-
-        yield return Expression;
     }
 
     protected override string NodeRepresentation() => "return";

--- a/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Statements/WhileStatement.cs
+++ b/src/HydraScript.Lib/IR/Ast/Impl/Nodes/Statements/WhileStatement.cs
@@ -3,6 +3,9 @@ namespace HydraScript.Lib.IR.Ast.Impl.Nodes.Statements;
 [AutoVisitable<AbstractSyntaxTreeNode>]
 public partial class WhileStatement : Statement
 {
+    protected override IReadOnlyList<AbstractSyntaxTreeNode> Children =>
+        [Condition, Statement];
+
     public Expression Condition { get; }
     public Statement Statement { get; }
 
@@ -13,12 +16,6 @@ public partial class WhileStatement : Statement
 
         Statement = statement;
         Statement.Parent = this;
-    }
-
-    public override IEnumerator<AbstractSyntaxTreeNode> GetEnumerator()
-    {
-        yield return Condition;
-        yield return Statement;
     }
 
     protected override string NodeRepresentation() => "while";

--- a/src/HydraScript.Lib/IR/Ast/Visitors/InstructionProvider.cs
+++ b/src/HydraScript.Lib/IR/Ast/Visitors/InstructionProvider.cs
@@ -32,9 +32,10 @@ public class InstructionProvider : VisitorBase<AbstractSyntaxTreeNode, Addressed
     public AddressedInstructions Visit(ScriptBody visitable)
     {
         var result = new AddressedInstructions();
-        foreach (var item in visitable.StatementList)
+        for (var i = 0; i < visitable.Count; i++)
         {
-            result.AddRange(item.Accept(This));
+            var instructions = visitable[i].Accept(This);
+            result.AddRange(instructions);
         }
 
         result.Add(new Halt());
@@ -47,8 +48,9 @@ public class InstructionProvider : VisitorBase<AbstractSyntaxTreeNode, Addressed
     public AddressedInstructions Visit(LexicalDeclaration visitable)
     {
         var result = new AddressedInstructions();
-        foreach (var assignment in visitable.Assignments)
+        for (var i = 0; i < visitable.Count; i++)
         {
+            var assignment = visitable[i];
             result.AddRange(assignment.Accept(_expressionVisitor));
         }
 
@@ -58,8 +60,9 @@ public class InstructionProvider : VisitorBase<AbstractSyntaxTreeNode, Addressed
     public AddressedInstructions Visit(BlockStatement visitable)
     {
         var result = new AddressedInstructions();
-        foreach (var item in visitable.StatementList)
+        for (var i = 0; i < visitable.Count; i++)
         {
+            var item = visitable[i];
             result.AddRange(item.Accept(This));
             if (item is ReturnStatement) break;
         }

--- a/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/ArrayAccessException.cs
+++ b/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/ArrayAccessException.cs
@@ -1,11 +1,8 @@
 using System.Diagnostics.CodeAnalysis;
-using HydraScript.Lib.FrontEnd.GetTokens.Data;
 
 namespace HydraScript.Lib.IR.CheckSemantics.Exceptions;
 
 [ExcludeFromCodeCoverage]
-public class ArrayAccessException : SemanticException
-{
-    public ArrayAccessException(Segment segment, Type type) :
-        base(segment, $"Array element cannot be accessed with type {type} it must be of type number") { }
-}
+public class ArrayAccessException(string segment, Type type) : SemanticException(
+    segment,
+    $"Array element cannot be accessed with type {type} it must be of type number");

--- a/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/AssignmentToConst.cs
+++ b/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/AssignmentToConst.cs
@@ -4,8 +4,5 @@ using HydraScript.Lib.IR.Ast.Impl.Nodes.Expressions.PrimaryExpressions;
 namespace HydraScript.Lib.IR.CheckSemantics.Exceptions;
 
 [ExcludeFromCodeCoverage]
-public class AssignmentToConst : SemanticException
-{
-    public AssignmentToConst(IdentifierReference ident) :
-        base(ident.Segment,$"Cannot assign to const: {ident.Name}") { }
-}
+public class AssignmentToConst(IdentifierReference ident)
+    : SemanticException(ident.Segment, $"Cannot assign to const: {ident.Name}");

--- a/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/CannotDefineType.cs
+++ b/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/CannotDefineType.cs
@@ -1,11 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
-using HydraScript.Lib.FrontEnd.GetTokens.Data;
 
 namespace HydraScript.Lib.IR.CheckSemantics.Exceptions;
 
 [ExcludeFromCodeCoverage]
-public class CannotDefineType : SemanticException
-{
-    public CannotDefineType(Segment segment) :
-        base(segment, "Cannot define type") { }
-}
+public class CannotDefineType(string segment) : SemanticException(segment, "Cannot define type");

--- a/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/ConstWithoutInitializer.cs
+++ b/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/ConstWithoutInitializer.cs
@@ -4,8 +4,5 @@ using HydraScript.Lib.IR.Ast.Impl.Nodes.Expressions.PrimaryExpressions;
 namespace HydraScript.Lib.IR.CheckSemantics.Exceptions;
 
 [ExcludeFromCodeCoverage]
-public class ConstWithoutInitializer : SemanticException
-{
-    public ConstWithoutInitializer(IdentifierReference ident) :
-        base(ident.Segment, $"'const' without initializer: {ident.Name}") { }
-}
+public class ConstWithoutInitializer(IdentifierReference ident) :
+    SemanticException(ident.Segment, $"'const' without initializer: {ident.Name}");

--- a/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/DeclarationAlreadyExists.cs
+++ b/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/DeclarationAlreadyExists.cs
@@ -4,8 +4,5 @@ using HydraScript.Lib.IR.Ast.Impl.Nodes.Expressions.PrimaryExpressions;
 namespace HydraScript.Lib.IR.CheckSemantics.Exceptions;
 
 [ExcludeFromCodeCoverage]
-public class DeclarationAlreadyExists : SemanticException
-{
-    public DeclarationAlreadyExists(IdentifierReference ident) :
-        base(ident.Segment, $"Declaration already exists: {ident.Name}") { }
-}
+public class DeclarationAlreadyExists(IdentifierReference ident) :
+    SemanticException(ident.Segment, $"Declaration already exists: {ident.Name}");

--- a/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/FunctionWithoutReturnStatement.cs
+++ b/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/FunctionWithoutReturnStatement.cs
@@ -1,11 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
-using HydraScript.Lib.FrontEnd.GetTokens.Data;
 
 namespace HydraScript.Lib.IR.CheckSemantics.Exceptions;
 
 [ExcludeFromCodeCoverage]
-public class FunctionWithoutReturnStatement : SemanticException
-{
-    public FunctionWithoutReturnStatement(Segment segment) :
-        base(segment, "function with non-void return type must have a return statement") { }
-}
+public class FunctionWithoutReturnStatement(string segment) :
+    SemanticException(segment, "function with non-void return type must have a return statement");

--- a/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/IncompatibleTypesOfOperands.cs
+++ b/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/IncompatibleTypesOfOperands.cs
@@ -1,11 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
-using HydraScript.Lib.FrontEnd.GetTokens.Data;
 
 namespace HydraScript.Lib.IR.CheckSemantics.Exceptions;
 
 [ExcludeFromCodeCoverage]
-public class IncompatibleTypesOfOperands : SemanticException
-{
-    public IncompatibleTypesOfOperands(Segment segment, Type left, Type right) :
-        base(segment, $"Incompatible types of operands: {left} and {right}") { }
-}
+public class IncompatibleTypesOfOperands(string segment, Type left, Type right) :
+    SemanticException(segment, $"Incompatible types of operands: {left} and {right}");

--- a/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/NonAccessibleType.cs
+++ b/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/NonAccessibleType.cs
@@ -3,8 +3,5 @@ using System.Diagnostics.CodeAnalysis;
 namespace HydraScript.Lib.IR.CheckSemantics.Exceptions;
 
 [ExcludeFromCodeCoverage]
-public class NonAccessibleType : SemanticException
-{
-    public NonAccessibleType(Type type) :
-        base($"Type '{type}' is not array-like or object-like") { }
-}
+public class NonAccessibleType(Type type) :
+    SemanticException($"Type '{type}' is not array-like or object-like");

--- a/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/NotBooleanTestExpression.cs
+++ b/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/NotBooleanTestExpression.cs
@@ -1,11 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
-using HydraScript.Lib.FrontEnd.GetTokens.Data;
 
 namespace HydraScript.Lib.IR.CheckSemantics.Exceptions;
 
 [ExcludeFromCodeCoverage]
-public class NotBooleanTestExpression : SemanticException
-{
-    public NotBooleanTestExpression(Segment segment, Type type) :
-        base(segment, $"Type of expression is {type} but expected boolean") { }
-}
+public class NotBooleanTestExpression(string segment, Type type) :
+    SemanticException(segment, $"Type of expression is {type} but expected boolean");

--- a/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/ObjectAccessException.cs
+++ b/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/ObjectAccessException.cs
@@ -1,12 +1,8 @@
 using System.Diagnostics.CodeAnalysis;
-using HydraScript.Lib.FrontEnd.GetTokens.Data;
 using HydraScript.Lib.IR.CheckSemantics.Types;
 
 namespace HydraScript.Lib.IR.CheckSemantics.Exceptions;
 
 [ExcludeFromCodeCoverage]
-public class ObjectAccessException : SemanticException
-{
-    public ObjectAccessException(Segment segment, ObjectType objectType, string field) :
-        base(segment, $"Object type {objectType} has no field {field}") { }
-}
+public class ObjectAccessException(string segment, ObjectType objectType, string field) :
+    SemanticException(segment, $"Object type {objectType} has no field {field}");

--- a/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/OutsideOfStatement.cs
+++ b/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/OutsideOfStatement.cs
@@ -1,11 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
-using HydraScript.Lib.FrontEnd.GetTokens.Data;
 
 namespace HydraScript.Lib.IR.CheckSemantics.Exceptions;
 
 [ExcludeFromCodeCoverage]
-public class OutsideOfStatement : SemanticException
-{
-    public OutsideOfStatement(Segment segment, string keyword, string statement) :
-        base(segment, $"Jump \"{keyword}\" outside of statement \"{statement}\"") { }
-}
+public class OutsideOfStatement(string segment, string keyword, string statement) :
+    SemanticException(segment, $"Jump \"{keyword}\" outside of statement \"{statement}\"");

--- a/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/ReturnOutsideFunction.cs
+++ b/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/ReturnOutsideFunction.cs
@@ -1,11 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
-using HydraScript.Lib.FrontEnd.GetTokens.Data;
 
 namespace HydraScript.Lib.IR.CheckSemantics.Exceptions;
 
 [ExcludeFromCodeCoverage]
-public class ReturnOutsideFunction : SemanticException
-{
-    public ReturnOutsideFunction(Segment segment) :
-        base(segment, "\"return\" outside function") { }
-}
+public class ReturnOutsideFunction(string segment) :
+    SemanticException(segment, "\"return\" outside function");

--- a/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/SemanticException.cs
+++ b/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/SemanticException.cs
@@ -1,17 +1,24 @@
 using System.Diagnostics.CodeAnalysis;
-using HydraScript.Lib.FrontEnd.GetTokens.Data;
 
 namespace HydraScript.Lib.IR.CheckSemantics.Exceptions;
 
 [Serializable, ExcludeFromCodeCoverage]
 public abstract class SemanticException : Exception
 {
-    protected SemanticException() { }
-        
-    protected SemanticException(string message) : base(message) { }
-        
-    protected SemanticException(string message, Exception inner) : base(message, inner) { }
-        
-    protected SemanticException(Segment segment, string message) :
-        base($"{segment} {message}") { }
+    protected SemanticException()
+    {
+    }
+
+    protected SemanticException(string message) : base(message)
+    {
+    }
+
+    protected SemanticException(string message, Exception inner) : base(message, inner)
+    {
+    }
+
+    protected SemanticException(string segment, string message) :
+        base($"{segment} {message}")
+    {
+    }
 }

--- a/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/SymbolIsNotCallable.cs
+++ b/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/SymbolIsNotCallable.cs
@@ -1,11 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
-using HydraScript.Lib.FrontEnd.GetTokens.Data;
 
 namespace HydraScript.Lib.IR.CheckSemantics.Exceptions;
 
 [ExcludeFromCodeCoverage]
-public class SymbolIsNotCallable : SemanticException
-{
-    public SymbolIsNotCallable(string symbol, Segment segment) : 
-        base(segment, $"Symbol is not callable: {symbol}") { }
-}
+public class SymbolIsNotCallable(string symbol, string segment) :
+    SemanticException(segment, $"Symbol is not callable: {symbol}");

--- a/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/UnknownIdentifierReference.cs
+++ b/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/UnknownIdentifierReference.cs
@@ -4,8 +4,5 @@ using HydraScript.Lib.IR.Ast.Impl.Nodes.Expressions.PrimaryExpressions;
 namespace HydraScript.Lib.IR.CheckSemantics.Exceptions;
 
 [ExcludeFromCodeCoverage]
-public class UnknownIdentifierReference : SemanticException
-{
-    public UnknownIdentifierReference(IdentifierReference ident) :
-        base(ident.Segment, $"Unknown identifier reference: {ident.Name}") { }
-}
+public class UnknownIdentifierReference(IdentifierReference ident) :
+    SemanticException(ident.Segment, $"Unknown identifier reference: {ident.Name}");

--- a/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/UnsupportedOperation.cs
+++ b/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/UnsupportedOperation.cs
@@ -1,11 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
-using HydraScript.Lib.FrontEnd.GetTokens.Data;
 
 namespace HydraScript.Lib.IR.CheckSemantics.Exceptions;
 
 [ExcludeFromCodeCoverage]
-public class UnsupportedOperation : SemanticException
-{
-    public UnsupportedOperation(Segment segment, Type type, string @operator) :
-        base(segment, $"Type {type} does not support operation {@operator}") { }
-}
+public class UnsupportedOperation(string segment, Type type, string @operator) :
+    SemanticException(segment, $"Type {type} does not support operation {@operator}");

--- a/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/WrongArrayLiteralDeclaration.cs
+++ b/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/WrongArrayLiteralDeclaration.cs
@@ -1,11 +1,9 @@
 using System.Diagnostics.CodeAnalysis;
-using HydraScript.Lib.FrontEnd.GetTokens.Data;
 
 namespace HydraScript.Lib.IR.CheckSemantics.Exceptions;
 
 [ExcludeFromCodeCoverage]
-public class WrongArrayLiteralDeclaration : SemanticException
-{
-    public WrongArrayLiteralDeclaration(Segment segment, Type type) : 
-        base(segment, $"{segment} Wrong array literal declaration: all array elements must be of type {type}") { }
-}
+public class WrongArrayLiteralDeclaration(string segment, Type type) :
+    SemanticException(
+        segment, 
+        $"Wrong array literal declaration: all array elements must be of type {type}");

--- a/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/WrongAssignmentTarget.cs
+++ b/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/WrongAssignmentTarget.cs
@@ -4,8 +4,7 @@ using HydraScript.Lib.IR.Ast.Impl.Nodes.Expressions;
 namespace HydraScript.Lib.IR.CheckSemantics.Exceptions;
 
 [ExcludeFromCodeCoverage]
-public class WrongAssignmentTarget : SemanticException
-{
-    public WrongAssignmentTarget(LeftHandSideExpression lhs) :
-        base(lhs.Segment, $"Assignment target must be variable, property or indexer. '{lhs.Id.Name}' is {lhs.GetType().Name}") { }
-}
+public class WrongAssignmentTarget(LeftHandSideExpression lhs) :
+    SemanticException(
+        lhs.Segment,
+        $"Assignment target must be variable, property or indexer. '{lhs.Id.Name}' is {lhs.GetType().Name}");

--- a/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/WrongConditionalTypes.cs
+++ b/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/WrongConditionalTypes.cs
@@ -1,11 +1,13 @@
 using System.Diagnostics.CodeAnalysis;
-using HydraScript.Lib.FrontEnd.GetTokens.Data;
 
 namespace HydraScript.Lib.IR.CheckSemantics.Exceptions;
 
 [ExcludeFromCodeCoverage]
-public class WrongConditionalTypes : SemanticException
-{
-    public WrongConditionalTypes(Segment cSegment, Type cType, Segment aSegment, Type aType) :
-        base(cSegment + aSegment, $"Different types in conditional:  {cSegment} consequent - {cType}, {aSegment} alternate {aType}") { }
-}
+public class WrongConditionalTypes(
+    string segment,
+    string cSegment,
+    Type cType,
+    string aSegment,
+    Type aType) : SemanticException(
+        segment,
+        $"Different types in conditional:  {cSegment} consequent - {cType}, {aSegment} alternate {aType}");

--- a/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/WrongNumberOfArguments.cs
+++ b/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/WrongNumberOfArguments.cs
@@ -1,11 +1,9 @@
 using System.Diagnostics.CodeAnalysis;
-using HydraScript.Lib.FrontEnd.GetTokens.Data;
 
 namespace HydraScript.Lib.IR.CheckSemantics.Exceptions;
 
 [ExcludeFromCodeCoverage]
-public class WrongNumberOfArguments : SemanticException
-{
-    public WrongNumberOfArguments(Segment segment, int expected, int actual) :
-        base(segment, $"Wrong number of arguments: expected {expected}, actual {actual}") { }
-}
+public class WrongNumberOfArguments(string segment, int expected, int actual) :
+    SemanticException(
+        segment,
+        $"Wrong number of arguments: expected {expected}, actual {actual}");

--- a/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/WrongReturnType.cs
+++ b/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/WrongReturnType.cs
@@ -1,11 +1,9 @@
 using System.Diagnostics.CodeAnalysis;
-using HydraScript.Lib.FrontEnd.GetTokens.Data;
 
 namespace HydraScript.Lib.IR.CheckSemantics.Exceptions;
 
 [ExcludeFromCodeCoverage]
-public class WrongReturnType : SemanticException
-{
-    public WrongReturnType(Segment segment, Type expected, Type actual) :
-        base(segment, $"Wrong return type: expected {expected}, actual {actual}") { }
-}
+public class WrongReturnType(string segment, Type expected, Type actual) :
+    SemanticException(
+        segment,
+        $"Wrong return type: expected {expected}, actual {actual}");

--- a/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/WrongTypeOfArgument.cs
+++ b/src/HydraScript.Lib/IR/CheckSemantics/Exceptions/WrongTypeOfArgument.cs
@@ -1,11 +1,9 @@
 using System.Diagnostics.CodeAnalysis;
-using HydraScript.Lib.FrontEnd.GetTokens.Data;
 
 namespace HydraScript.Lib.IR.CheckSemantics.Exceptions;
 
 [ExcludeFromCodeCoverage]
-public class WrongTypeOfArgument : SemanticException
-{
-    public WrongTypeOfArgument(Segment segment, Type expected, Type actual) :
-        base(segment,$"Wrong type of argument: expected {expected}, actual {actual}") { }
-}
+public class WrongTypeOfArgument(string segment, Type expected, Type actual) :
+    SemanticException(
+        segment,
+        $"Wrong type of argument: expected {expected}, actual {actual}");

--- a/src/HydraScript.Lib/IR/CheckSemantics/Visitors/DeclarationVisitor.cs
+++ b/src/HydraScript.Lib/IR/CheckSemantics/Visitors/DeclarationVisitor.cs
@@ -27,16 +27,17 @@ public class DeclarationVisitor : VisitorNoReturnBase<AbstractSyntaxTreeNode>,
 
     public override VisitUnit Visit(AbstractSyntaxTreeNode visitable)
     {
-        foreach (var child in visitable)
-            child.Accept(This);
+        for (var i = 0; i < visitable.Count; i++)
+            visitable[i].Accept(This);
 
         return default;
     }
 
     public VisitUnit Visit(LexicalDeclaration visitable)
     {
-        foreach (var assignment in visitable.Assignments)
+        for (var i = 0; i < visitable.Assignments.Count; i++)
         {
+            var assignment = visitable.Assignments[i];
             if (visitable.SymbolTable.ContainsSymbol(assignment.Destination.Id))
                 throw new DeclarationAlreadyExists(assignment.Destination.Id);
 

--- a/src/HydraScript.Lib/IR/CheckSemantics/Visitors/DeclarationVisitor.cs
+++ b/src/HydraScript.Lib/IR/CheckSemantics/Visitors/DeclarationVisitor.cs
@@ -60,7 +60,7 @@ public class DeclarationVisitor : VisitorNoReturnBase<AbstractSyntaxTreeNode>,
 
     public VisitUnit Visit(FunctionDeclaration visitable)
     {
-        if (visitable.Parent!.SymbolTable.ContainsSymbol(visitable.Name))
+        if (visitable.Parent.SymbolTable.ContainsSymbol(visitable.Name))
             throw new DeclarationAlreadyExists(visitable.Name);
 
         var parameters = visitable.Arguments.Select(x =>

--- a/src/HydraScript.Lib/IR/CheckSemantics/Visitors/SemanticChecker.cs
+++ b/src/HydraScript.Lib/IR/CheckSemantics/Visitors/SemanticChecker.cs
@@ -56,8 +56,8 @@ public class SemanticChecker : VisitorBase<AbstractSyntaxTreeNode, Type>,
 
     public Type Visit(ScriptBody visitable)
     {
-        foreach (var statementListItem in visitable.StatementList)
-            statementListItem.Accept(This);
+        for (var i = 0; i < visitable.Count; i++)
+            visitable[i].Accept(This);
 
         foreach (var funcDecl in _functionStorage.Flush())
             funcDecl.Accept(This);
@@ -250,8 +250,9 @@ public class SemanticChecker : VisitorBase<AbstractSyntaxTreeNode, Type>,
     {
         Type undefined = "undefined";
 
-        foreach (var assignment in visitable.Assignments)
+        for (var i = 0; i < visitable.Assignments.Count; i++)
         {
+            var assignment = visitable.Assignments[i];
             var registeredSymbol = visitable.SymbolTable.FindSymbol<VariableSymbol>(
                 assignment.Destination.Id);
             var sourceType = assignment.Source.Accept(This);
@@ -423,7 +424,7 @@ public class SemanticChecker : VisitorBase<AbstractSyntaxTreeNode, Type>,
         _functionStorage.RemoveIfPresent(symbol);
         visitable.Statements.Accept(This);
 
-        var returnStatements = visitable.GetReturnStatements()
+        var returnStatements = visitable.ReturnStatements
             .Select(x => new
             {
                 Statement = x,
@@ -461,7 +462,8 @@ public class SemanticChecker : VisitorBase<AbstractSyntaxTreeNode, Type>,
 
     public Type Visit(BlockStatement visitable)
     {
-        visitable.StatementList.ForEach(x => x.Accept(This));
+        for (var i = 0; i < visitable.Count; i++)
+            visitable[i].Accept(This);
         return "undefined";
     }
 }

--- a/src/HydraScript.Lib/IR/CheckSemantics/Visitors/SemanticChecker.cs
+++ b/src/HydraScript.Lib/IR/CheckSemantics/Visitors/SemanticChecker.cs
@@ -181,6 +181,7 @@ public class SemanticChecker : VisitorBase<AbstractSyntaxTreeNode, Type>,
             return cType;
 
         throw new WrongConditionalTypes(
+            segment: visitable.Segment,
             cSegment: visitable.Consequent.Segment,
             cType,
             aSegment: visitable.Alternate.Segment,

--- a/src/HydraScript.Lib/IR/CheckSemantics/Visitors/SemanticChecker.cs
+++ b/src/HydraScript.Lib/IR/CheckSemantics/Visitors/SemanticChecker.cs
@@ -131,11 +131,11 @@ public class SemanticChecker : VisitorBase<AbstractSyntaxTreeNode, Type>,
     }
 
     public Type Visit(Literal visitable) =>
-        visitable.Type.BuildType(visitable.Parent!.SymbolTable);
+        visitable.Type.BuildType(visitable.Parent.SymbolTable);
 
     public Type Visit(ImplicitLiteral visitable)
     {
-        var type = visitable.TypeValue.BuildType(visitable.Parent!.SymbolTable);
+        var type = visitable.TypeValue.BuildType(visitable.Parent.SymbolTable);
         visitable.ComputedDefaultValue = _calculator.GetDefaultValueForType(type);
         return type;
     }

--- a/src/HydraScript.Lib/IR/CheckSemantics/Visitors/Services/Impl/SymbolTableInitializerService.cs
+++ b/src/HydraScript.Lib/IR/CheckSemantics/Visitors/Services/Impl/SymbolTableInitializerService.cs
@@ -5,11 +5,11 @@ namespace HydraScript.Lib.IR.CheckSemantics.Visitors.Services.Impl;
 internal class SymbolTableInitializerService : ISymbolTableInitializerService
 {
     public void InitThroughParent(AbstractSyntaxTreeNode node) =>
-        node.SymbolTable = node.Parent!.SymbolTable;
+        node.SymbolTable = node.Parent.SymbolTable;
 
     public void InitWithNewScope(AbstractSyntaxTreeNode node)
     {
         node.SymbolTable = new();
-        node.SymbolTable.AddOpenScope(node.Parent!.SymbolTable);
+        node.SymbolTable.AddOpenScope(node.Parent.SymbolTable);
     }
 }

--- a/src/HydraScript.Lib/IR/CheckSemantics/Visitors/SymbolTableInitializer.cs
+++ b/src/HydraScript.Lib/IR/CheckSemantics/Visitors/SymbolTableInitializer.cs
@@ -25,15 +25,17 @@ public class SymbolTableInitializer : VisitorNoReturnBase<AbstractSyntaxTreeNode
     public override VisitUnit Visit(AbstractSyntaxTreeNode visitable)
     {
         _initializerService.InitThroughParent(visitable);
-        foreach (var child in visitable)
-            child.Accept(This);
+        for (var i = 0; i < visitable.Count; i++)
+            visitable[i].Accept(This);
+
         return default;
     }
 
     public VisitUnit Visit(ScriptBody visitable)
     {
         visitable.SymbolTable = _provider.GetStandardLibrary();
-        visitable.StatementList.ForEach(item => item.Accept(This));
+        for (var i = 0; i < visitable.Count; i++)
+            visitable[i].Accept(This);
         return default;
     }
 
@@ -47,7 +49,8 @@ public class SymbolTableInitializer : VisitorNoReturnBase<AbstractSyntaxTreeNode
     public VisitUnit Visit(BlockStatement visitable)
     {
         _initializerService.InitWithNewScope(visitable);
-        visitable.StatementList.ForEach(item => item.Accept(This));
+        for (var i = 0; i < visitable.Count; i++)
+            visitable[i].Accept(This);
         return default;
     }
 }

--- a/src/HydraScript.Lib/IR/CheckSemantics/Visitors/TypeSystemLoader.cs
+++ b/src/HydraScript.Lib/IR/CheckSemantics/Visitors/TypeSystemLoader.cs
@@ -24,15 +24,16 @@ public class TypeSystemLoader : VisitorNoReturnBase<AbstractSyntaxTreeNode>,
 
     public VisitUnit Visit(ScriptBody visitable)
     {
-        visitable.StatementList.ForEach(item => item.Accept(This));
+        for (var i = 0; i < visitable.Count; i++)
+            visitable[i].Accept(This);
         _resolver.Resolve();
         return default;
     }
 
     public override VisitUnit Visit(AbstractSyntaxTreeNode visitable)
     {
-        foreach (var child in visitable)
-            child.Accept(This);
+        for (var i = 0; i < visitable.Count; i++)
+            visitable[i].Accept(This);
 
         return default;
     }

--- a/tests/HydraScript.Tests/Unit/IR/AstNodeTests.cs
+++ b/tests/HydraScript.Tests/Unit/IR/AstNodeTests.cs
@@ -13,19 +13,19 @@ public class AstNodeTests
     public void PrecedenceTest()
     {
         var lexicalDecl = new LexicalDeclaration(false);
-        var stmtItemList = new List<StatementListItem>
-        {
-            lexicalDecl
-        };
+        List<StatementListItem> stmtItemList = [lexicalDecl];
         // ReSharper disable once UnusedVariable
         var func = new FunctionDeclaration(
             name: new IdentifierReference(name: Guid.NewGuid().ToString()),
             new TypeIdentValue(
                 TypeId: new IdentifierReference(
                     name: Guid.NewGuid().ToString())),
-            arguments: new List<PropertyTypeValue>(),
+            arguments: [],
             new BlockStatement(stmtItemList));
 
+        _ = new ScriptBody([func]);
+
         Assert.True(lexicalDecl.ChildOf<FunctionDeclaration>());
+        Assert.False(lexicalDecl.ChildOf<Literal>());
     }
 }


### PR DESCRIPTION
### Description
`AbstractSyntaxTreeNode` теперь реализует `IReadOnlyList` вместо `IEnumerable`


### Related Issues
Подзадача #31
Closes #59 


### References
<!--- References would be helpful to understand the changes. -->
<!--- References can be books, links, etc. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [ ] I have added corresponding labels with respect to the part of the interpreter i've worked on.
