### PR TITLE
Внедрение ITestOutputHelper через xUnit DI +semver:skip

### DIFF
--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -1,14 +1,15 @@
 <Project>
-    <ItemGroup>
-        <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-        <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
-        <PackageVersion Include="FluentAssertions" Version="6.12.0" />
-        <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.4.0" />
-        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.1" />
-        <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.8.0" />
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-        <PackageVersion Include="NSubstitute" Version="5.1.0" />
-        <PackageVersion Include="xunit" Version="2.9.0" />
-        <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+    <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+    <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.4.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.1" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.8.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageVersion Include="NSubstitute" Version="5.1.0" />
+    <PackageVersion Include="xunit" Version="2.9.0" />
+    <PackageVersion Include="Xunit.DependencyInjection" Version="9.4.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
 </Project>

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -1,15 +1,15 @@
 <Project>
-  <ItemGroup>
-    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-    <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
-    <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.4.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.1" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.8.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageVersion Include="NSubstitute" Version="5.1.0" />
-    <PackageVersion Include="xunit" Version="2.9.0" />
-    <PackageVersion Include="Xunit.DependencyInjection" Version="9.4.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+        <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
+        <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+        <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.4.0" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.1" />
+        <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.8.0" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+        <PackageVersion Include="NSubstitute" Version="5.1.0" />
+        <PackageVersion Include="xunit" Version="2.9.0" />
+        <PackageVersion Include="Xunit.DependencyInjection" Version="9.4.0" />
+        <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    </ItemGroup>
 </Project>

--- a/tests/HydraScript.IntegrationTests/ErrorPrograms/VariableInitializationTests.cs
+++ b/tests/HydraScript.IntegrationTests/ErrorPrograms/VariableInitializationTests.cs
@@ -1,19 +1,16 @@
 using System.CommandLine.Parsing;
 using FluentAssertions;
-using Xunit.Abstractions;
 
 namespace HydraScript.IntegrationTests.ErrorPrograms;
 
-public class VariableInitializationTests(
-    TestHostFixture fixture,
-    ITestOutputHelper testOutputHelper) : IClassFixture<TestHostFixture>
+public class VariableInitializationTests(TestHostFixture fixture) : IClassFixture<TestHostFixture>
 {
     [Theory, MemberData(nameof(VariableInitializationScripts))]
     public void VariableWithoutTypeDeclared_AccessedBeforeInitialization_ExitCodeHydraScriptError(string script)
     {
         var runner = fixture.GetRunner(
-            testOutputHelper,
-            configureTestServices: services => services.SetupInMemoryScript(script));
+            configureTestServices: services =>
+                services.SetupInMemoryScript(script));
         var code = runner.Invoke(fixture.InMemoryScript);
         code.Should().Be(ExitCodes.HydraScriptError);
         fixture.LogMessages.Should()

--- a/tests/HydraScript.IntegrationTests/HydraScript.IntegrationTests.csproj
+++ b/tests/HydraScript.IntegrationTests/HydraScript.IntegrationTests.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+    <PropertyGroup>
+        <NoWarn>CA1816</NoWarn>
+    </PropertyGroup>
+    
     <ItemGroup>
         <PackageReference Include="FluentAssertions" />
         <PackageReference Include="MartinCostello.Logging.XUnit" />
@@ -7,6 +11,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="NSubstitute" />
         <PackageReference Include="xunit" />
+        <PackageReference Include="Xunit.DependencyInjection" />
         <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/tests/HydraScript.IntegrationTests/Startup.cs
+++ b/tests/HydraScript.IntegrationTests/Startup.cs
@@ -1,0 +1,7 @@
+namespace HydraScript.IntegrationTests;
+
+// ReSharper disable once UnusedType.Global
+/// <summary>
+/// https://github.com/pengweiqhca/Xunit.DependencyInjection#4-default-startup
+/// </summary>
+public class Startup;

--- a/tests/HydraScript.IntegrationTests/SuccessfulProgramsTests.cs
+++ b/tests/HydraScript.IntegrationTests/SuccessfulProgramsTests.cs
@@ -1,17 +1,14 @@
 using System.CommandLine.Parsing;
 using FluentAssertions;
-using Xunit.Abstractions;
 
 namespace HydraScript.IntegrationTests;
 
-public class SuccessfulProgramsTests(
-    TestHostFixture fixture,
-    ITestOutputHelper testOutputHelper) : IClassFixture<TestHostFixture>
+public class SuccessfulProgramsTests(TestHostFixture fixture) : IClassFixture<TestHostFixture>
 {
     [Theory, MemberData(nameof(SuccessfulProgramsNames))]
     public void Invoke_NoError_ReturnCodeIsZero(string fileName)
     {
-        var runner = fixture.GetRunner(testOutputHelper);
+        var runner = fixture.GetRunner();
         var code = runner.Invoke([$"Samples/{fileName}"]);
         code.Should().Be(ExitCodes.Success);
     }


### PR DESCRIPTION
### Description
https://stackoverflow.com/a/73141087

При создании новых интеграционников я бы упёрся в проблему копипасты бойлерплейта:
1. Запросить `ITestOutputHelper` в конструкторе тестового класса
2. Передать в `fixture.GetRunner`

Удалось избежать рутины, прописав один раз DI надстройку