### PR TITLE
Issues 152

### DIFF
--- a/tests/HydraScript.IntegrationTests/SuccessfulProgramsTests.cs
+++ b/tests/HydraScript.IntegrationTests/SuccessfulProgramsTests.cs
@@ -11,7 +11,6 @@ public class SuccessfulProgramsTests(TestHostFixture fixture) : IClassFixture<Te
         var runner = fixture.GetRunner(
             new TestHostFixture.Options(
                 FileName: relativePathToFile,
-
                 MockFileSystem: false));
         var code = runner.Invoke();
         code.Should().Be(Executor.ExitCodes.Success);

--- a/tests/HydraScript.IntegrationTests/SuccessfulProgramsTests.cs
+++ b/tests/HydraScript.IntegrationTests/SuccessfulProgramsTests.cs
@@ -5,7 +5,7 @@ namespace HydraScript.IntegrationTests;
 public class SuccessfulProgramsTests(TestHostFixture fixture) : IClassFixture<TestHostFixture>
 {
     [Theory]
-    [ClassData(typeof(SamplesScriptsData))]
+    [ClassData(typeof(SuccessfulPrograms))]
     public void Invoke_NoError_ReturnCodeIsZero(string relativePathToFile)
     {
         var runner = fixture.GetRunner(
@@ -16,9 +16,9 @@ public class SuccessfulProgramsTests(TestHostFixture fixture) : IClassFixture<Te
         code.Should().Be(Executor.ExitCodes.Success);
     }
 
-    public class SamplesScriptsData : TheoryData<string>
+    public class SuccessfulPrograms : TheoryData<string>
     {
-        public SamplesScriptsData()
+        public SuccessfulPrograms()
         {
             AddRange(Directory.GetFiles("Samples"));
         }

--- a/tests/HydraScript.IntegrationTests/SuccessfulProgramsTests.cs
+++ b/tests/HydraScript.IntegrationTests/SuccessfulProgramsTests.cs
@@ -4,51 +4,24 @@ namespace HydraScript.IntegrationTests;
 
 public class SuccessfulProgramsTests(TestHostFixture fixture) : IClassFixture<TestHostFixture>
 {
-    [Theory, MemberData(nameof(SuccessfulProgramsNames))]
-    public void Invoke_NoError_ReturnCodeIsZero(string fileName)
+    [Theory]
+    [ClassData(typeof(SamplesScriptsData))]
+    public void Invoke_NoError_ReturnCodeIsZero(string relativePathToFile)
     {
         var runner = fixture.GetRunner(
             new TestHostFixture.Options(
-                FileName: $"Samples/{fileName}",
+                FileName: relativePathToFile,
+
                 MockFileSystem: false));
         var code = runner.Invoke();
         code.Should().Be(Executor.ExitCodes.Success);
     }
 
-    public static TheoryData<string> SuccessfulProgramsNames =>
-        new(
-        [
-            "abs.js",
-            "arraddremove.js",
-            "arreditread.js",
-            "ceil.js",
-            "cycled.js",
-            "defaultarray.js",
-            "equals.js",
-            "exprtest.js",
-            "fastpow.js",
-            "forwardref.js",
-            "gcd.js",
-            "lcm.js",
-            "linkedlist.js",
-            "objeditread.js",
-            "overload.js",
-            "overload_object.js",
-            "posneg.js",
-            "prime.js",
-            "primefactor.js",
-            "quicksort.js",
-            "range.js",
-            "recur.js",
-            "scope.js",
-            "searchinll.js",
-            "settable.js",
-            "squareroot.js",
-            "summator.js",
-            "tern.js",
-            "this.js",
-            "typeresolving.js",
-            "vec2d.js",
-            "xxx.js"
-        ]);
+    public class SamplesScriptsData : TheoryData<string>
+    {
+        public SamplesScriptsData()
+        {
+            AddRange(Directory.GetFiles("Samples"));
+        }
+    }
 }


### PR DESCRIPTION
Read all files from the Samples folder, no need to add the folder to the test manually.

### Description
Создаем класс SamplesScriptsData, наследуемся от TheoryData<string> как в предложенной реализации. 


### Related Issues
 https://github.com/Stepami/hydrascript/issues/152

### References
Наследовался от TheoryData<string> как сделано тут:
https://github.com/Stepami/hydrascript/blob/master/tests/HydraScript.UnitTests/Domain/FrontEnd/LexerData.cs


### Checklist: