### PR TITLE
Issue 162

### DIFF
--- a/src/HydraScript/Program.cs
+++ b/src/HydraScript/Program.cs
@@ -18,14 +18,14 @@ internal static partial class Program
         {
             var fileInfo = parseResult.GetValue(command.PathArgument)!;
             var dump = parseResult.GetValue(command.DumpOption);
-            var serviceProvider = GetServiceProvider(fileInfo, dump);
+            using var serviceProvider = GetServiceProvider(fileInfo, dump);
             var executor = serviceProvider.GetRequiredService<Executor>();
             return executor.Invoke();
         });
         return command;
     }
 
-    internal static IServiceProvider GetServiceProvider(
+    internal static ServiceProvider GetServiceProvider(
         FileInfo fileInfo,
         bool dump,
         Action<IServiceCollection>? configureServices = null)

--- a/tests/HydraScript.IntegrationTests/DumpOptionTests.cs
+++ b/tests/HydraScript.IntegrationTests/DumpOptionTests.cs
@@ -9,7 +9,7 @@ public class DumpOptionTests(TestHostFixture fixture) : IClassFixture<TestHostFi
     [Fact]
     public void Invoke_DumpOptionPassed_FilesCreated()
     {
-        var runner = fixture.GetRunner(new TestHostFixture.Options(Dump: true));
+        using var runner = fixture.GetRunner(new TestHostFixture.Options(Dump: true));
         runner.Invoke();
 
         var fileSystemMock = runner.ServiceProvider.GetRequiredService<IFileSystem>();

--- a/tests/HydraScript.IntegrationTests/ErrorPrograms/NullAssignmentWhenUndefinedTests.cs
+++ b/tests/HydraScript.IntegrationTests/ErrorPrograms/NullAssignmentWhenUndefinedTests.cs
@@ -7,7 +7,7 @@ public class NullAssignmentWhenUndefinedTests(TestHostFixture fixture) : IClassF
     [Theory, MemberData(nameof(NullAssignmentScripts))]
     public void NullAssignment_UndefinedDestinationOrReturnType_HydraScriptError(string script)
     {
-        var runner = fixture.GetRunner(new TestHostFixture.Options(InMemoryScript: script));
+        using var runner = fixture.GetRunner(new TestHostFixture.Options(InMemoryScript: script));
         var code = runner.Invoke();
         code.Should().Be(Executor.ExitCodes.HydraScriptError);
         fixture.LogMessages.Should()

--- a/tests/HydraScript.IntegrationTests/ErrorPrograms/VariableInitializationTests.cs
+++ b/tests/HydraScript.IntegrationTests/ErrorPrograms/VariableInitializationTests.cs
@@ -7,7 +7,7 @@ public class VariableInitializationTests(TestHostFixture fixture) : IClassFixtur
     [Theory, MemberData(nameof(VariableInitializationScripts))]
     public void VariableWithoutTypeDeclared_AccessedBeforeInitialization_HydraScriptError(string script)
     {
-        var runner = fixture.GetRunner(new TestHostFixture.Options(InMemoryScript: script));
+        using var runner = fixture.GetRunner(new TestHostFixture.Options(InMemoryScript: script));
         var code = runner.Invoke();
         code.Should().Be(Executor.ExitCodes.HydraScriptError);
         fixture.LogMessages.Should()

--- a/tests/HydraScript.IntegrationTests/ErrorPrograms/VoidAssignmentTests.cs
+++ b/tests/HydraScript.IntegrationTests/ErrorPrograms/VoidAssignmentTests.cs
@@ -16,7 +16,7 @@ public class VoidAssignmentTests(TestHostFixture fixture) : IClassFixture<TestHo
                 }
                 let x = func(true)
             """;
-        var runner = fixture.GetRunner(new TestHostFixture.Options(InMemoryScript: script));
+        using var runner = fixture.GetRunner(new TestHostFixture.Options(InMemoryScript: script));
         var code = runner.Invoke();
         code.Should().Be(Executor.ExitCodes.HydraScriptError);
         fixture.LogMessages.Should()

--- a/tests/HydraScript.IntegrationTests/SuccessfulProgramsTests.cs
+++ b/tests/HydraScript.IntegrationTests/SuccessfulProgramsTests.cs
@@ -8,7 +8,7 @@ public class SuccessfulProgramsTests(TestHostFixture fixture) : IClassFixture<Te
     [ClassData(typeof(SuccessfulPrograms))]
     public void Invoke_NoError_ReturnCodeIsZero(string relativePathToFile)
     {
-        var runner = fixture.GetRunner(
+        using var runner = fixture.GetRunner(
             new TestHostFixture.Options(
                 FileName: relativePathToFile,
                 MockFileSystem: false));

--- a/tests/HydraScript.IntegrationTests/TestHostFixture.cs
+++ b/tests/HydraScript.IntegrationTests/TestHostFixture.cs
@@ -18,10 +18,15 @@ public class TestHostFixture(
         bool MockFileSystem = true,
         string InMemoryScript = "");
 
-    public class Runner(IServiceProvider serviceProvider, Executor executor)
+    public class Runner(ServiceProvider serviceProvider, Executor executor): IDisposable
     {
-        public IServiceProvider ServiceProvider => serviceProvider;
+        public ServiceProvider ServiceProvider => serviceProvider;
         public int Invoke() => executor.Invoke();
+
+        public void Dispose()
+        {
+            serviceProvider.Dispose();
+        }
     }
 
     private readonly List<string> _logMessages = [];


### PR DESCRIPTION
Работаем с ServiceProvider вместо IServiceProvider, так как ServiceProvider реализует IDisposable и позволяет при завершении работы программы корректно(насильно) писать логи, а не терять их.

### Description
Работаем с ServiceProvider вместо IServiceProvider, так как ServiceProvider реализует IDisposable и позволяет при завершении работы программы корректно(насильно) писать логи, а не терять их.


### Related Issues
 https://github.com/Stepami/hydrascript/issues/162


### References
<!--- References would be helpful to understand the changes. -->
<!--- References can be books, links, etc. -->


### Checklist:
Корректен ли для тебя отказ от IServiceProvider в ServiceProvider ?
Кажется покрыть тестами такой баг нельзя, по крайней мере с ходу.
